### PR TITLE
fix: don't add top margin to items preceded by hidden inputs

### DIFF
--- a/src/css/layouts/_form.css
+++ b/src/css/layouts/_form.css
@@ -1,3 +1,7 @@
 form > * + * {
     margin-block-start: 2em;
 }
+
+form > [type="hidden"] + * {
+    margin-block-start: 0;
+}


### PR DESCRIPTION
Currently the `<form>` layout makes use of the adjacent sibling operator to ensure that elements are given an appropriate block start (top) margin:

```css
form > * + * {
    margin-block-start: 2em;
}
```

This causes unexpected behaviour when a hidden form input (`<input type="hidden">`) is present, as it  creates an unexpected margin on the subsequent element. This PR adds an additional rule to reset the block start (top) margin for elements which follow a hidden form input.